### PR TITLE
Fix typo overwriting MYSQL_ROOT_PASSWORD

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -6,7 +6,7 @@ set -x
 MYSQL_ROOT_PASSWORD=`tr -dc A-Za-z0-9_ < /dev/urandom | head -c 20 | xargs`
 
 echo "MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}" > env
-echo "KNOWN_DB_PASSWORD=${MYSQL_ROOT_PASSWORD}" > env
+echo "KNOWN_DB_PASSWORD=${MYSQL_ROOT_PASSWORD}" >> env
 echo "MAIL_PASS=${MAIL_PASS}" >> env
 echo "MAIL_USER=${MAIL_USER}" >> env
 echo "MAIL_HOST=${MAIL_HOST}" >> env


### PR DESCRIPTION
First line gets overwritten.

Fix for https://github.com/indiehosters/libre.sh/issues/143